### PR TITLE
Fix get_endpoint to allow / in parameters

### DIFF
--- a/src/thingset.cpp
+++ b/src/thingset.cpp
@@ -120,30 +120,32 @@ DataNode *const ThingSet::get_node(node_id_t id)
 
 DataNode *const ThingSet::get_endpoint(const char *path, size_t len)
 {
-    const DataNode *node;
+    DataNode *node;
     const char *start = path;
-    const char *end = strchr(path, '/');
+    const char *end;
     uint16_t parent = 0;
 
     // maximum depth of 10 assumed
     for (int i = 0; i < 10; i++) {
-        if (end != NULL) {
-            if (end - path != (int)len - 1) {
-                node = get_node(start, end - start, parent);
-                if (!node) {
-                    return NULL;
-                }
-                parent = node->id;
-                start = end + 1;
-                end = strchr(start, '/');
-            }
-            else {
-                // resource ends with trailing slash
-                return get_node(start, end - start, parent);
-            }
+        end = strchr(start, '/');
+        if (end == NULL || end >= path + len) {
+            // we are at the end of the path
+            return get_node(start, path + len - start, parent);
+        }
+        else if (end == path + len - 1) {
+            // path ends with slash
+            return get_node(start, end - start, parent);
         }
         else {
-            return get_node(start, path + len - start, parent);
+            // go further down the path
+            node = get_node(start, end - start, parent);
+            if (node) {
+                parent = node->id;
+                start = end + 1;
+            }
+            else {
+                return NULL;
+            }
         }
     }
     return NULL;

--- a/src/thingset.h
+++ b/src/thingset.h
@@ -362,8 +362,8 @@ public:
     /**
      * Get the endpoint node of a provided path
      *
-     * @param path Path of with multiple node names divided by forward slash
-     * @param len Length of the node name
+     * @param path Path with multiple node names separated by forward slash
+     * @param len Length of the entire path
      *
      * @returns Pointer to data node or NULL if node is not found
      */

--- a/test/tests_txt.cpp
+++ b/test/tests_txt.cpp
@@ -324,6 +324,19 @@ void test_txt_get_endpoint()
     node = ts.get_endpoint("conf/", strlen("conf/"));
     TEST_ASSERT_NOT_NULL(node);
     TEST_ASSERT_EQUAL(node->id, ID_CONF);
+
+    node = ts.get_endpoint("/", strlen("/"));
+    TEST_ASSERT_NULL(node);
+
+    // special case where the data contains forward slashes
+    node = ts.get_endpoint("conf \"this/is/a/path\"", strlen("conf"));
+    TEST_ASSERT_NOT_NULL(node);
+    TEST_ASSERT_EQUAL(node->id, ID_CONF);
+
+    // special case where the data contains forward slashes
+    node = ts.get_endpoint("exec/reset \"this/is/a/path\"", strlen("exec/reset"));
+    TEST_ASSERT_NOT_NULL(node);
+    TEST_ASSERT_EQUAL(node->id, 0xE1);
 }
 
 void tests_text_mode()


### PR DESCRIPTION
The previous function returned `NULL` if one of the parameters in the data section contained a slash (e.g. if it was a string containing a path). 

This PR fixes the function and adds unit tests to cover this case.