### PR TITLE
Fix CBOR deserialization of UINT32_MAX

### DIFF
--- a/src/cbor.c
+++ b/src/cbor.c
@@ -316,7 +316,7 @@ int cbor_deserialize_uint32(const uint8_t *data, uint32_t *value)
         return 0;
 
     size = _cbor_uint_data(data, &tmp);
-    if (size > 0 && tmp <= INT32_MAX) {
+    if (size > 0 && tmp <= UINT32_MAX) {
         *value = tmp;
         return size;
     }

--- a/test/test_common.c
+++ b/test/test_common.c
@@ -167,7 +167,7 @@ void test_bin_patch_txt_fetch(void)
     TEST_ASSERT_CBOR2JSON("ui32", "65535", 0x6003, "19 FF FF");
     TEST_ASSERT_CBOR2JSON("ui32", "65535", 0x6003, "1A 00 00 FF FF");  // less compact format
     TEST_ASSERT_CBOR2JSON("ui32", "65536", 0x6003, "1A 00 01 00 00");
-    TEST_ASSERT_JSON2CBOR("ui32", "4294967295", 0x6003, "1A FF FF FF FF"); // @TODO ????
+    TEST_ASSERT_CBOR2JSON("ui32", "4294967295", 0x6003, "1A FF FF FF FF");
 
     // uint64
     #if TS_64BIT_TYPES_SUPPORT


### PR DESCRIPTION
@b0661 I saw your `@TODO ????` comment in the cbor2json unit tests. This must have been a typo introduced a while ago and it turned out this test (if applied in right direction) would have detected an actual bug.

This commit fixes both test and implementation.