### PR TITLE
Add support to import a record element in binary mode

### DIFF
--- a/src/thingset.h
+++ b/src/thingset.h
@@ -868,7 +868,7 @@ int ts_txt_statement_by_id(struct ts_context *ts, char *buf, size_t buf_size, ts
  * @param ts Pointer to ThingSet context.
  * @param buf Pointer to the buffer where the publication message should be stored
  * @param buf_size Size of the message buffer, i.e. maximum allowed length of the message
- * @param object Group or subset object specifying the items to be published
+ * @param object Records object with the data to be published
  * @param record_index Element number extracted from path (only used for records).
  *
  * @returns Actual length of the message written to the buffer or 0 in case of error
@@ -894,8 +894,8 @@ int ts_bin_export(struct ts_context *ts, uint8_t *buf, size_t buf_size, uint16_t
 /**
  * Generate statement message in CBOR format based on pointer to group or subset.
  *
- * This is the fastest method to generate a statement as it does not require to search through the
- * entire date nodes array.
+ * This is the fastest method to generate a statement as it avoids searching through the entire
+ * data objects array.
  *
  * @param ts Pointer to ThingSet context.
  * @param buf Pointer to the buffer where the publication message should be stored
@@ -966,8 +966,25 @@ int ts_bin_pub_can(struct ts_context *ts, int *start_pos, uint16_t subset, uint8
  *
  * @returns ThingSet status code
  */
-int ts_bin_import(struct ts_context *ts, uint8_t *data, size_t len, uint8_t auth_flags,
+int ts_bin_import(struct ts_context *ts, const uint8_t *data, size_t len, uint8_t auth_flags,
                   uint16_t subsets);
+
+/**
+ * Import data in CBOR format as a record.
+ *
+ * @param ts Pointer to ThingSet context.
+ * @param data Buffer containing ID/value map that should be written to the record
+ * @param len Length of the data in the buffer
+ * @param auth_flags Authentication flags to be used in this function (to override _auth_flags)
+ * @param subsets Flags to select which subset(s) of data items should be imported
+ * @param object Records object with the data to be published
+ * @param record_index Index of the record to which the data should be written.
+ *
+ * @returns ThingSet status code
+ */
+int ts_bin_import_record(struct ts_context *ts, const uint8_t *data, size_t len,
+                         uint8_t auth_flags, uint16_t subsets,
+                         struct ts_data_object *object, int record_index);
 
 /**
  * Get data object by ID.

--- a/src/thingset_priv.h
+++ b/src/thingset_priv.h
@@ -134,9 +134,10 @@ int ts_txt_patch(struct ts_context *ts, const struct ts_data_object *endpoint);
  * @param pos_payload Position of payload in req buffer
  * @param auth_flags Bitset to specify authentication status for different roles
  * @param subsets Bitset to specifiy data item subsets to be considered, 0 to ignore
+ * @param record_index Record index (only applicable for TS_T_RECORDS).
  */
 int ts_bin_patch(struct ts_context *ts, const struct ts_data_object *endpoint,
-                 unsigned int pos_payload, uint8_t auth_flags, uint16_t subsets);
+                 unsigned int pos_payload, uint8_t auth_flags, uint16_t subsets, int record_index);
 
 /**
  * POST request to append data.

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -140,6 +140,7 @@ void tests_binary_mode()
     // data export/import
     RUN_TEST(test_bin_export);
     RUN_TEST(test_bin_import);
+    RUN_TEST(test_bin_import_record);
 
     // update notification
     RUN_TEST(test_bin_update_callback);

--- a/test/test.h
+++ b/test/test.h
@@ -200,6 +200,7 @@ void test_bin_deserialize_bytes(void);
 void test_bin_patch_fetch_bytes(void);
 void test_bin_export(void);
 void test_bin_import(void);
+void test_bin_import_record(void);
 void test_bin_update_callback(void);
 void test_bin_fetch_paths(void);
 void test_bin_fetch_ids(void);

--- a/test/test_bin.c
+++ b/test/test_bin.c
@@ -371,6 +371,42 @@ void test_bin_import(void)
     TEST_ASSERT_EQUAL(TS_STATUS_CHANGED, ret);
 }
 
+void test_bin_import_record(void)
+{
+    /* only update 2 of the existing elements */
+    const uint8_t data[] = {
+        0xA2,
+            0x18, 0x81,
+            0x18, 0x7C, // 124
+            0x18, 0x83,
+            0x05,       // 5
+    };
+
+    struct ts_data_object *obj = ts_get_object_by_path(&ts, "Log", strlen("Log"));
+
+    int ret = ts_bin_import_record(&ts, data, sizeof(data), TS_WRITE_MASK, 0, obj, 0);
+
+    TEST_ASSERT_EQUAL(TS_STATUS_CHANGED, ret);
+
+    const uint8_t req[] = {
+        TS_FETCH,
+        0x19, 0x70, 0x05,
+        0x00 // first record
+    };
+    const uint8_t resp_expected[] = {
+        0x85,
+        0xA3,
+            0x18, 0x81,
+            0x18, 0x7C, // 124
+            0x18, 0x82,
+            0xFA, 0x41, 0x48, 0x00, 0x00, // 12.5
+            0x18, 0x83,
+            0x05
+    };
+
+    TEST_ASSERT_BIN_REQ_EXP_BIN(req, sizeof(req), resp_expected, sizeof(resp_expected));
+}
+
 void test_bin_exec(void)
 {
     dummy_called_flag = 0;

--- a/test/test_data.c
+++ b/test/test_data.c
@@ -200,7 +200,7 @@ struct ts_data_object data_objects[] = {
 
     // RECORDS used for logs //////////////////////////////////////////////////
 
-    TS_RECORDS(0x7005, "Log", &records, ID_ROOT, TS_ANY_R, 0),
+    TS_RECORDS(0x7005, "Log", &records, ID_ROOT, TS_ANY_RW, 0),
 
     /*
     * Record items definition.

--- a/zephyr/tests/src/main.c
+++ b/zephyr/tests/src/main.c
@@ -111,6 +111,7 @@ void test_main(void)
         /* Bin mode: exporting/importing of data */
         ztest_unit_test_setup_teardown(test_bin_export, setup, teardown),
         ztest_unit_test_setup_teardown(test_bin_import, setup, teardown),
+        ztest_unit_test_setup_teardown(test_bin_import_record, setup, teardown),
         /* Bin mode: update notification */
         ztest_unit_test_setup_teardown(test_bin_update_callback, setup, teardown),
         /* Bin mode: request paths by IDs and vice versa */


### PR DESCRIPTION
This allows to aggregate data received from other nodes:

1. Store one record per similar node on the bus.
2. Store historic data from one node (e.g. including received timestamp)